### PR TITLE
WHFHRI-740

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -99,7 +99,7 @@ jobs:
   docker-build:
     name: Docker Build
     needs: build
-    #if: ${{ github.ref == 'refs/heads/develop' }}
+    if: ${{ github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: mgmt-api

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -99,7 +99,7 @@ jobs:
   docker-build:
     name: Docker Build
     needs: build
-    if: ${{ github.ref == 'refs/heads/develop' }}
+    #if: ${{ github.ref == 'refs/heads/develop' }}
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: mgmt-api

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ ok  	github.com/Alvearie/hri-mgmt-api/tenants	0.316s	coverage: 100.0% of stateme
 cd src; GOOS=linux GOACH=amd64 go build
 ```
 
+### Troubleshooting
+If you encounter this error:
+```
+rdkafka#producer-1| [thrd:sasl_ssl://...]: sasl_ssl://.../bootstrap: SSL handshake failed: error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed: broker certificate could not be verified, verify that ssl.ca.location is correctly configured or root CA certificates are installed (brew install openssl)
+```
+There is a problem with the default root CA. See the Confluent [documentation](https://docs.confluent.io/platform/current/tutorials/examples/clients/docs/go.html#configure-ssl-trust-store) for instructions on how to fix it.
+
 ## CI/CD
 This application can be run locally, but almost all the endpoints require Elasticsearch, Kafka, and an OIDC server. GitHub actions builds and runs integration tests using a common Elastic Search and Event Streams instance. You can perform local manual testing using these resources. See [test/README.md](test/README.md) for more details.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,8 +5,13 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4 AS builder
 
 RUN microdnf update -y && \
-    microdnf -y install golang-1.15.14 make && \
+    microdnf -y install make tar gzip gcc && \
     microdnf clean all
+
+RUN curl -f https://dl.google.com/go/go1.15.15.linux-amd64.tar.gz -o /tmp/golang.tar.gz && \
+    tar -C /usr/local/ -xzf /tmp/golang.tar.gz
+
+ENV PATH=$PATH:/usr/local/go/bin
 
 COPY ./ /hri-mgmt-api/
 WORKDIR /hri-mgmt-api

--- a/test/README.md
+++ b/test/README.md
@@ -77,6 +77,9 @@
      
     ```rspec test/spec --tag ~@broken```
     
+### Troubleshooting
+If you encounter rdkafka SSL root CA certificate errors, see [Troubleshooting](READMD.md#troubleshooting) for instructions on how to update you local root CA certificates. To set the `ssl.ca.location` property for the tests, in `test/spec/hri_deploy_helper.rb` add it to the command line override of `-kafka-properties`, but ensure you don't commit this or it will break the GitHub Actions tests. 
+
 # Dredd Tests
 Dredd is used to verify the implemented API meets our published [specification](https://github.com/Alvearie/hri-api-spec/blob/develop/management-api/management.yml).
 By default, it generates a test for every endpoint, uses the example values for input, and verifies the response matches the 200 response schema. All other responses are skipped. Ruby 'hooks' are used to modify the default behavior and do setup/teardown.

--- a/test/README.md
+++ b/test/README.md
@@ -78,7 +78,7 @@
     ```rspec test/spec --tag ~@broken```
     
 ### Troubleshooting
-If you encounter rdkafka SSL root CA certificate errors, see [Troubleshooting](READMD.md#troubleshooting) for instructions on how to update you local root CA certificates. To set the `ssl.ca.location` property for the tests, in `test/spec/hri_deploy_helper.rb` add it to the command line override of `-kafka-properties`, but ensure you don't commit this or it will break the GitHub Actions tests. 
+If you encounter rdkafka SSL root CA certificate errors, see [Troubleshooting](READMD.md#troubleshooting) for instructions on how to update your local root CA certificates. To set the `ssl.ca.location` property for the tests, in `test/spec/hri_deploy_helper.rb` add it to the command line override of `-kafka-properties`, but ensure you don't commit this or it will break the GitHub Actions tests. 
 
 # Dredd Tests
 Dredd is used to verify the implemented API meets our published [specification](https://github.com/Alvearie/hri-api-spec/blob/develop/management-api/management.yml).


### PR DESCRIPTION
Updated docker build to manually download and install go 1.15.15
Added instructions to the README for rdkafka SSL errors

## PR Requirements:
 - [ ] The code must be reviewed by at least one Maintainer
 - [x] JIRA Ticket: https://jira.wh-sdlc.watson-health.ibm.com/browse/WHFHRI-740
 - [x] 90 % test code coverage
 - [x] README updates